### PR TITLE
feat: add public holiday calendar search and provider integration

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -102,10 +102,10 @@ The application has been updated to be more responsive. Key changes include:
 
 *   **Tool Output Verification:** After performing file writes with LLM tools, verify that no critical sections (like `<script>` blocks) were accidentally truncated or omitted, especially when working with large Vue SFCs.
 
-### Lessons Learned (Session: Custom Currencies & Data Management)
+### Lessons Learned (Session: Public Holiday Calendars & Provider Pattern)
 
-*   **Datalists for UX:** Using `<datalist>` instead of `<select>` provides a superior "combo-box" experience, allowing users to select from a large list of standard options (like ISO 4217 currencies) while still maintaining the flexibility to enter custom values (like "CPU Tokens") that haven't been globally defined yet.
-*   **Centralized Data Providers:** For data required by multiple nested components (e.g., the consolidated list of standard + custom currencies), using Vue's `provide/inject` pattern is more maintainable and cleaner than "prop drilling" through several layers of components.
-*   **Comprehensive Data Fetching:** When implementing standard lists (currencies, countries, etc.), fetching a complete dataset via `curl` or external APIs during development ensures better utility than manually creating a small, incomplete subset.
-*   **Strict Mode in Testing:** When tests fail due to "strict mode violations" in Playwright, it's often a sign that the UI has become more complex with similar repeating elements. Use container-specific locators (e.g., `parent.locator('input')`) rather than global selectors to ensure reliability.
-*   **Markdown Integration:** When reflecting new data types (like custom currency conversions) in human-readable views (Description tab), ensure that the logic handles edge cases like missing conversion rates or partial data gracefully to avoid broken formatting.
+*   **Datalist Searchability:** Using `<datalist>` combined with a text input is an effective way to provide "search-as-you-type" functionality for external resources (like iCal URLs) without requiring a full-blown autocomplete component or external library.
+*   **Dependency Injection in Tests:** When using Vue's `provide/inject` pattern, Vitest/Vue Test Utils `mount` calls must be updated to include `global: { provide: { ... } }`. This ensures components that rely on injected data don't fail during unit testing.
+*   **Reverse Lookups for UX:** When storing raw data (like a Google Calendar URL), providing a reverse-lookup utility (`getHolidayCalendarName`) is essential for maintaining a high-quality human-readable "Description" view, as it allows displaying the friendly name instead of a cryptic URI.
+*   **Official URL Patterns:** Many public resources (like Google Calendar holidays) follow predictable patterns (`[lang].[country].official#holiday@...`). Hardcoding these patterns in a utility, combined with special-case overrides, allows for a lightweight but comprehensive "dynamic" list.
+*   **Integration Test Visibility:** When testing UI changes that affect generated output (like YAML in an Ace Editor), ensure the test script explicitly navigates to the "Source" tab (or whichever view contains the output) to ensure Playwright can "see" and assert against the DOM content.

--- a/src/App.vue
+++ b/src/App.vue
@@ -128,6 +128,7 @@
 <script>
 import { ref, onMounted, onUnmounted, watch, reactive, computed, provide } from 'vue';
 import { currencies } from './utils/currencies';
+import { getAllHolidayCalendars, getGoogleHolidayCalendarUrl } from './utils/holidays';
 import 'bootstrap/dist/css/bootstrap.css';
 import ace from 'ace-builds';
 import 'ace-builds/src-noconflict/mode-yaml';
@@ -215,6 +216,10 @@ export default {
     });
 
     provide('availableCurrencies', availableCurrencies);
+    provide('holidayCalendars', {
+      all: getAllHolidayCalendars(),
+      getUrl: getGoogleHolidayCalendarUrl
+    });
 
     const ajv = new Ajv({ allErrors: true });
     addFormats(ajv);

--- a/src/components/PolicyDescription.vue
+++ b/src/components/PolicyDescription.vue
@@ -8,6 +8,7 @@
 import { computed } from 'vue';
 import { marked } from 'marked';
 import { formatDuration, formatRRule, hasContent } from '../utils/formatters';
+import { getHolidayCalendarName } from '../utils/holidays';
 
 export default {
   name: 'PolicyDescription',
@@ -157,7 +158,14 @@ export default {
                 support.holidaySchedule.sources.forEach(s => {
                   if (s.type === 'region') md += `- Regional holidays for **${s.regionCode}**\n`;
                   else if (s.type === 'manual' && s.dates) md += `- Specified dates: ${s.dates.join(', ')}\n`;
-                  else if (s.type === 'ical') md += `- Calendar feed: ${s.calendarUrl}\n`;
+                  else if (s.type === 'ical') {
+                    const calendarName = getHolidayCalendarName(s.calendarUrl);
+                    if (calendarName) {
+                      md += `- **${calendarName}** (from feed: ${s.calendarUrl})\n`;
+                    } else {
+                      md += `- Calendar feed: ${s.calendarUrl}\n`;
+                    }
+                  }
                   if (s.description) md += `  *${s.description}*\n`;
                 });
                 md += `\n`;

--- a/src/components/SupportPolicyEditor.vue
+++ b/src/components/SupportPolicyEditor.vue
@@ -97,7 +97,7 @@
 
       <!-- Holiday Schedule -->
       <h6 class="mt-4">Holiday Schedule</h6>
-      <div v-for="(source, index) in safeSupportPolicy.holidaySchedule ? safeSupportPolicy.holidaySchedule.sources : []" :key="index" class="card mb-2 p-2">
+      <div v-for="(source, index) in safeSupportPolicy.holidaySchedule ? safeSupportPolicy.holidaySchedule.sources : []" :key="index" class="card mb-2 p-2 holiday-source-item">
         <div class="d-flex justify-content-between align-items-center mb-2">
           <span>Source #{{ index + 1 }}</span>
           <button class="btn btn-danger btn-sm" @click="removeHolidaySource(index)">Remove</button>
@@ -122,10 +122,16 @@
         </div>
         <div v-if="source.type === 'ical'" class="mb-3">
           <label class="form-label">Calendar URL</label>
-          <input type="text" class="form-control" :class="{'is-invalid': errors[path + '/holidaySchedule/sources/' + index + '/calendarUrl']}" placeholder="https://example.com/holidays.ics" :value="source.calendarUrl" @input="updateHolidaySource(index, 'calendarUrl', $event.target.value)">
-          <div class="invalid-feedback" v-if="errors[path + '/holidaySchedule/sources/' + index + '/calendarUrl']">
+          <div class="input-group">
+            <input type="text" class="form-control" :class="{'is-invalid': errors[path + '/holidaySchedule/sources/' + index + '/calendarUrl']}" placeholder="https://example.com/holidays.ics" :value="source.calendarUrl" @input="updateHolidaySource(index, 'calendarUrl', $event.target.value)" :list="'holiday-calendars-' + index">
+            <datalist :id="'holiday-calendars-' + index">
+              <option v-for="cal in allHolidayCalendars" :key="cal.id" :value="getGoogleHolidayCalendarUrl(cal.id)">{{ cal.name }}</option>
+            </datalist>
+          </div>
+          <div class="invalid-feedback d-block" v-if="errors[path + '/holidaySchedule/sources/' + index + '/calendarUrl']">
             {{ errors[path + '/holidaySchedule/sources/' + index + '/calendarUrl'].join(', ') }}
           </div>
+          <div class="form-text">Search for a country to find its Google Holiday Calendar.</div>
         </div>
         <div v-if="source.type === 'manual'" class="mb-3">
           <label class="form-label">Dates (comma-separated YYYY-MM-DD)</label>
@@ -151,7 +157,7 @@
 </template>
 
 <script>
-import { computed } from 'vue';
+import { computed, inject } from 'vue';
 import DurationEditor from './DurationEditor.vue';
 import ServiceLevelObjectivesEditor from './ServiceLevelObjectivesEditor.vue';
 
@@ -182,6 +188,7 @@ export default {
   emits: ['update:supportPolicy'],
   setup(props, { emit }) {
     const safeSupportPolicy = computed(() => props.supportPolicy || {});
+    const holidayData = inject('holidayCalendars', { all: [], getUrl: () => '' });
 
     const updateSupportPolicy = (newPolicy) => {
       emit('update:supportPolicy', newPolicy);
@@ -338,6 +345,8 @@ export default {
 
     return {
       safeSupportPolicy,
+      allHolidayCalendars: holidayData.all,
+      getGoogleHolidayCalendarUrl: holidayData.getUrl,
       addHours,
       updateHours,
       removeHours,

--- a/src/utils/holidays.js
+++ b/src/utils/holidays.js
@@ -1,0 +1,229 @@
+export const holidayCalendars = [
+  { name: "Andorra", code: "AD" },
+  { name: "Albania", code: "AL" },
+  { name: "Armenia", code: "AM" },
+  { name: "Argentina", code: "AR" },
+  { name: "Austria", code: "AT" },
+  { name: "Australia", code: "AU" },
+  { name: "Åland Islands", code: "AX" },
+  { name: "Bosnia and Herzegovina", code: "BA" },
+  { name: "Barbados", code: "BB" },
+  { name: "Belgium", code: "BE" },
+  { name: "Bulgaria", code: "BG" },
+  { name: "Benin", code: "BJ" },
+  { name: "Bolivia", code: "BO" },
+  { name: "Brazil", code: "BR" },
+  { name: "Bahamas", code: "BS" },
+  { name: "Botswana", code: "BW" },
+  { name: "Belarus", code: "BY" },
+  { name: "Belize", code: "BZ" },
+  { name: "Canada", code: "CA" },
+  { name: "DR Congo", code: "CD" },
+  { name: "Congo", code: "CG" },
+  { name: "Switzerland", code: "CH" },
+  { name: "Chile", code: "CL" },
+  { name: "China", code: "CN" },
+  { name: "Colombia", code: "CO" },
+  { name: "Costa Rica", code: "CR" },
+  { name: "Cuba", code: "CU" },
+  { name: "Cyprus", code: "CY" },
+  { name: "Czechia", code: "CZ" },
+  { name: "Germany", code: "DE" },
+  { name: "Denmark", code: "DK" },
+  { name: "Dominican Republic", code: "DO" },
+  { name: "Ecuador", code: "EC" },
+  { name: "Estonia", code: "EE" },
+  { name: "Egypt", code: "EG" },
+  { name: "Spain", code: "ES" },
+  { name: "Finland", code: "FI" },
+  { name: "Faroe Islands", code: "FO" },
+  { name: "France", code: "FR" },
+  { name: "Gabon", code: "GA" },
+  { name: "United Kingdom", code: "GB" },
+  { name: "Grenada", code: "GD" },
+  { name: "Georgia", code: "GE" },
+  { name: "Guernsey", code: "GG" },
+  { name: "Ghana", code: "GH" },
+  { name: "Gibraltar", code: "GI" },
+  { name: "Greenland", code: "GL" },
+  { name: "Gambia", code: "GM" },
+  { name: "Greece", code: "GR" },
+  { name: "Guatemala", code: "GT" },
+  { name: "Guyana", code: "GY" },
+  { name: "Hong Kong", code: "HK" },
+  { name: "Honduras", code: "HN" },
+  { name: "Croatia", code: "HR" },
+  { name: "Haiti", code: "HT" },
+  { name: "Hungary", code: "HU" },
+  { name: "Indonesia", code: "ID" },
+  { name: "Ireland", code: "IE" },
+  { name: "Isle of Man", code: "IM" },
+  { name: "Iceland", code: "IS" },
+  { name: "Italy", code: "IT" },
+  { name: "Jersey", code: "JE" },
+  { name: "Jamaica", code: "JM" },
+  { name: "Japan", code: "JP" },
+  { name: "Kenya", code: "KE" },
+  { name: "South Korea", code: "KR" },
+  { name: "Kazakhstan", code: "KZ" },
+  { name: "Liechtenstein", code: "LI" },
+  { name: "Lesotho", code: "LS" },
+  { name: "Lithuania", code: "LT" },
+  { name: "Luxembourg", code: "LU" },
+  { name: "Latvia", code: "LV" },
+  { name: "Morocco", code: "MA" },
+  { name: "Monaco", code: "MC" },
+  { name: "Moldova", code: "MD" },
+  { name: "Montenegro", code: "ME" },
+  { name: "Madagascar", code: "MG" },
+  { name: "North Macedonia", code: "MK" },
+  { name: "Mongolia", code: "MN" },
+  { name: "Montserrat", code: "MS" },
+  { name: "Malta", code: "MT" },
+  { name: "Mexico", code: "MX" },
+  { name: "Mozambique", code: "MZ" },
+  { name: "Namibia", code: "NA" },
+  { name: "Niger", code: "NE" },
+  { name: "Nigeria", code: "NG" },
+  { name: "Nicaragua", code: "NI" },
+  { name: "Netherlands", code: "NL" },
+  { name: "Norway", code: "NO" },
+  { name: "New Zealand", code: "NZ" },
+  { name: "Panama", code: "PA" },
+  { name: "Peru", code: "PE" },
+  { name: "Papua New Guinea", code: "PG" },
+  { name: "Philippines", code: "PH" },
+  { name: "Poland", code: "PL" },
+  { name: "Puerto Rico", code: "PR" },
+  { name: "Portugal", code: "PT" },
+  { name: "Paraguay", code: "PY" },
+  { name: "Romania", code: "RO" },
+  { name: "Serbia", code: "RS" },
+  { name: "Russia", code: "RU" },
+  { name: "Sweden", code: "SE" },
+  { name: "Singapore", code: "SG" },
+  { name: "Slovenia", code: "SI" },
+  { name: "Svalbard and Jan Mayen", code: "SJ" },
+  { name: "Slovakia", code: "SK" },
+  { name: "San Marino", code: "SM" },
+  { name: "Suriname", code: "SR" },
+  { name: "El Salvador", code: "SV" },
+  { name: "Tunisia", code: "TN" },
+  { name: "Türkiye", code: "TR" },
+  { name: "Ukraine", code: "UA" },
+  { name: "United States", code: "US" },
+  { name: "Uruguay", code: "UY" },
+  { name: "Vatican City", code: "VA" },
+  { name: "Venezuela", code: "VE" },
+  { name: "Vietnam", code: "VN" },
+  { name: "South Africa", code: "ZA" },
+  { name: "Zimbabwe", code: "ZW" }
+];
+
+// Special cases for Google Calendar IDs that don't follow the simple pattern
+export const specialHolidayCalendars = [
+  { name: "Australian Holidays", id: "en.australian.official#holiday@group.v.calendar.google.com" },
+  { name: "Austrian Holidays", id: "en.austrian.official#holiday@group.v.calendar.google.com" },
+  { name: "Brazilian Holidays", id: "en.brazilian.official#holiday@group.v.calendar.google.com" },
+  { name: "Canadian Holidays", id: "en.canadian.official#holiday@group.v.calendar.google.com" },
+  { name: "China Holidays", id: "en.china.official#holiday@group.v.calendar.google.com" },
+  { name: "Christian Holidays", id: "en.christian#holiday@group.v.calendar.google.com" },
+  { name: "Danish Holidays", id: "en.danish.official#holiday@group.v.calendar.google.com" },
+  { name: "Dutch Holidays", id: "en.dutch.official#holiday@group.v.calendar.google.com" },
+  { name: "Finnish Holidays", id: "en.finnish.official#holiday@group.v.calendar.google.com" },
+  { name: "French Holidays", id: "en.french.official#holiday@group.v.calendar.google.com" },
+  { name: "German Holidays", id: "en.german.official#holiday@group.v.calendar.google.com" },
+  { name: "Greek Holidays", id: "en.greek.official#holiday@group.v.calendar.google.com" },
+  { name: "Hong Kong Holidays", id: "en.hong_kong.official#holiday@group.v.calendar.google.com" },
+  { name: "Indian Holidays", id: "en.indian.official#holiday@group.v.calendar.google.com" },
+  { name: "Indonesian Holidays", id: "en.indonesian.official#holiday@group.v.calendar.google.com" },
+  { name: "Iranian Holidays", id: "en.iranian#holiday@group.v.calendar.google.com" },
+  { name: "Irish Holidays", id: "en.irish.official#holiday@group.v.calendar.google.com" },
+  { name: "Islamic Holidays", id: "en.islamic#holiday@group.v.calendar.google.com" },
+  { name: "Italian Holidays", id: "en.italian.official#holiday@group.v.calendar.google.com" },
+  { name: "Japanese Holidays", id: "en.japanese.official#holiday@group.v.calendar.google.com" },
+  { name: "Jewish Holidays", id: "en.jewish.official#holiday@group.v.calendar.google.com" },
+  { name: "Malaysian Holidays", id: "en.malaysia.official#holiday@group.v.calendar.google.com" },
+  { name: "Mexican Holidays", id: "en.mexican.official#holiday@group.v.calendar.google.com" },
+  { name: "New Zealand Holidays", id: "en.new_zealand.official#holiday@group.v.calendar.google.com" },
+  { name: "Norwegian Holidays", id: "en.norwegian.official#holiday@group.v.calendar.google.com" },
+  { name: "Philippines Holidays", id: "en.philippines.official#holiday@group.v.calendar.google.com" },
+  { name: "Polish Holidays", id: "en.polish.official#holiday@group.v.calendar.google.com" },
+  { name: "Portuguese Holidays", id: "en.portuguese.official#holiday@group.v.calendar.google.com" },
+  { name: "Russian Holidays", id: "en.russian.official#holiday@group.v.calendar.google.com" },
+  { name: "Singapore Holidays", id: "en.singapore.official#holiday@group.v.calendar.google.com" },
+  { name: "South Africa Holidays", id: "en.sa.official#holiday@group.v.calendar.google.com" },
+  { name: "South Korean Holidays", id: "en.south_korea.official#holiday@group.v.calendar.google.com" },
+  { name: "Spain Holidays", id: "en.spain.official#holiday@group.v.calendar.google.com" },
+  { name: "Swedish Holidays", id: "en.swedish.official#holiday@group.v.calendar.google.com" },
+  { name: "Taiwan Holidays", id: "en.taiwan.official#holiday@group.v.calendar.google.com" },
+  { name: "Thai Holidays", id: "en.thai.official#holiday@group.v.calendar.google.com" },
+  { name: "UK Holidays", id: "en.uk.official#holiday@group.v.calendar.google.com" },
+  { name: "US Holidays", id: "en.usa.official#holiday@group.v.calendar.google.com" },
+  { name: "Vietnamese Holidays", id: "en.vietnamese.official#holiday@group.v.calendar.google.com" },
+  // German States
+  { name: "Germany: Baden-Württemberg Holidays", id: "de.bw#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Bavaria Holidays", id: "de.by#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Berlin Holidays", id: "de.be#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Brandenburg Holidays", id: "de.bb#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Bremen Holidays", id: "de.hb#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Hamburg Holidays", id: "de.hh#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Hessen Holidays", id: "de.he#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Mecklenburg-Vorpommern Holidays", id: "de.mv#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Niedersachsen Holidays", id: "de.ni#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Nordrhein-Westfalen Holidays", id: "de.nw#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Rheinland-Pfalz Holidays", id: "de.rp#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Saarland Holidays", id: "de.sl#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Sachsen Holidays", id: "de.sn#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Sachsen-Anhalt Holidays", id: "de.st#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Schleswig-Holstein Holidays", id: "de.sh#holiday@group.v.calendar.google.com" },
+  { name: "Germany: Thüringen Holidays", id: "de.th#holiday@group.v.calendar.google.com" }
+];
+
+export function getGoogleHolidayCalendarUrl(id) {
+  // Replace # with %23 and @ with %40 for the URL
+  const encodedId = id.replace(/#/g, '%23').replace(/@/g, '%40');
+  return `https://calendar.google.com/calendar/ical/${encodedId}/public/basic.ics`;
+}
+
+export function getHolidayCalendarId(code) {
+  // Check special cases first
+  // Try exact match on the name or specialized logic
+  if (code.toUpperCase() === 'US') return 'en.usa.official#holiday@group.v.calendar.google.com';
+  if (code.toUpperCase() === 'DE') return 'en.german.official#holiday@group.v.calendar.google.com';
+  if (code.toUpperCase() === 'GB' || code.toUpperCase() === 'UK') return 'en.uk.official#holiday@group.v.calendar.google.com';
+
+  const special = specialHolidayCalendars.find(c => {
+    const name = c.name.toLowerCase();
+    const search = code.toLowerCase();
+    // Match "Country Holidays" or "Country: ..."
+    return name === `${search} holidays` || name.startsWith(`${search}:`);
+  });
+  if (special) return special.id;
+
+  // Default pattern: en.[code].official#holiday@group.v.calendar.google.com
+  return `en.${code.toLowerCase()}.official#holiday@group.v.calendar.google.com`;
+}
+
+export function getAllHolidayCalendars() {
+  const all = [...specialHolidayCalendars];
+  
+  holidayCalendars.forEach(country => {
+    const id = getHolidayCalendarId(country.code);
+    if (!all.find(c => c.id === id)) {
+      all.push({
+        name: `${country.name} Holidays`,
+        id: id
+      });
+    }
+  });
+
+  return all.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function getHolidayCalendarName(url) {
+  if (!url) return null;
+  const all = getAllHolidayCalendars();
+  const found = all.find(c => getGoogleHolidayCalendarUrl(c.id) === url);
+  return found ? found.name : null;
+}

--- a/tests/components/SupportPolicyEditor.vitest.spec.ts
+++ b/tests/components/SupportPolicyEditor.vitest.spec.ts
@@ -1,8 +1,19 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import SupportPolicyEditor from '../../src/components/SupportPolicyEditor.vue'
+import { getAllHolidayCalendars, getGoogleHolidayCalendarUrl } from '../../src/utils/holidays'
 
 describe('SupportPolicyEditor', () => {
+  // Global provide for components that use inject
+  const globalOptions = {
+    provide: {
+      holidayCalendars: {
+        all: getAllHolidayCalendars(),
+        getUrl: getGoogleHolidayCalendarUrl
+      }
+    }
+  };
+
   // Helper to create a basic supportPolicy object for props
   const createBaseSupportPolicy = () => ({
     hoursAvailable: [],
@@ -15,6 +26,7 @@ describe('SupportPolicyEditor', () => {
       props: {
         supportPolicy: createBaseSupportPolicy(),
       },
+      global: globalOptions
     })
     expect(wrapper.text()).toContain('Support Policy')
     expect(wrapper.text()).toContain('Hours Available')
@@ -26,6 +38,7 @@ describe('SupportPolicyEditor', () => {
   it('adds new hours available', async () => {
     const wrapper = mount(SupportPolicyEditor, {
       props: { supportPolicy: createBaseSupportPolicy() },
+      global: globalOptions
     })
     await wrapper.findAll('button.btn-secondary.btn-sm').filter(w => w.text().includes("Add Hours"))[0].trigger('click')
     expect(wrapper.emitted('update:supportPolicy')[0][0].hoursAvailable.length).toBe(1)
@@ -38,7 +51,7 @@ describe('SupportPolicyEditor', () => {
       holidaySchedule: { sources: [] },
       serviceLevelObjectives: [],
     };
-    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy } })
+    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy }, global: globalOptions })
 
     // Select Tuesday
     const tuesdayCheckbox = wrapper.find('input#day-0-Tuesday')
@@ -56,7 +69,7 @@ describe('SupportPolicyEditor', () => {
 
   it('applies Workdays preset', async () => {
     const policy = { hoursAvailable: [{ dayOfWeek: [], opens: '', closes: '' }] };
-    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy } })
+    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy }, global: globalOptions })
     
     await wrapper.findAll('button.btn-outline-primary').filter(w => w.text().includes("Workdays"))[0].trigger('click')
     const updated = wrapper.emitted('update:supportPolicy')[0][0].hoursAvailable[0]
@@ -67,7 +80,7 @@ describe('SupportPolicyEditor', () => {
 
   it('applies 24x7 preset', async () => {
     const policy = { hoursAvailable: [{ dayOfWeek: [], opens: '', closes: '' }] };
-    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy } })
+    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy }, global: globalOptions })
     
     await wrapper.findAll('button.btn-outline-primary').filter(w => w.text().includes("24x7"))[0].trigger('click')
     const updated = wrapper.emitted('update:supportPolicy')[0][0].hoursAvailable[0]
@@ -82,7 +95,7 @@ describe('SupportPolicyEditor', () => {
       holidaySchedule: { sources: [] },
       serviceLevelObjectives: [],
     };
-    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy } })
+    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy }, global: globalOptions })
 
     // Find the remove button for hours available, it's the danger button inside the first card's header div
     await wrapper.findAll('.card-body .card.mb-2 .btn-danger.btn-sm').filter(w => w.text() === "Remove")[0].trigger('click') 
@@ -91,7 +104,7 @@ describe('SupportPolicyEditor', () => {
 
   // Holiday Schedule Tests
   it('adds a new holiday source (region)', async () => {
-    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: createBaseSupportPolicy() } })
+    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: createBaseSupportPolicy() }, global: globalOptions })
     await wrapper.findAll('button.btn-secondary.btn-sm').filter(w => w.text().includes("Add Holiday Source"))[0].trigger('click')
     expect(wrapper.emitted('update:supportPolicy')[0][0].holidaySchedule.sources.length).toBe(1)
     expect(wrapper.emitted('update:supportPolicy')[0][0].holidaySchedule.sources[0]).toEqual({ type: 'region' })
@@ -101,7 +114,7 @@ describe('SupportPolicyEditor', () => {
   })
 
   it('adds a new holiday source (ical)', async () => {
-    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: createBaseSupportPolicy() } })
+    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: createBaseSupportPolicy() }, global: globalOptions })
     await wrapper.findAll('button.btn-secondary.btn-sm').filter(w => w.text().includes("Add Holiday Source"))[0].trigger('click')
     await wrapper.find('select').setValue('ical') // Change type to iCal
     expect(wrapper.emitted('update:supportPolicy')[1][0].holidaySchedule.sources[0].type).toBe('ical')
@@ -116,7 +129,7 @@ describe('SupportPolicyEditor', () => {
       holidaySchedule: { sources: [{ type: 'region', regionCode: 'DE' }] },
       serviceLevelObjectives: [],
     };
-    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy } })
+    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy }, global: globalOptions })
 
     // Find the remove button for holiday source
     await wrapper.findAll('.card.mb-2.p-2 > .d-flex > .btn-danger.btn-sm')[0].trigger('click') 
@@ -125,7 +138,7 @@ describe('SupportPolicyEditor', () => {
 
   it('updates support policy when SLOs change', async () => {
     const policy = createBaseSupportPolicy();
-    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy } });
+    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy }, global: globalOptions });
     
     const sloEditor = wrapper.getComponent({ name: 'ServiceLevelObjectivesEditor' });
     const newSlos = [{ priority: 'High', name: 'Test', guarantees: [] }];
@@ -138,7 +151,7 @@ describe('SupportPolicyEditor', () => {
 
   // Contact Points and Channels Tests
   it('adds a new contact point and channel', async () => {
-    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: createBaseSupportPolicy() } })
+    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: createBaseSupportPolicy() }, global: globalOptions })
     await wrapper.findAll('button.btn-secondary').filter(w => w.text().includes("Add Contact Point"))[0].trigger('click')
     expect(wrapper.emitted('update:supportPolicy')[0][0].contactPoints.length).toBe(1)
     
@@ -156,7 +169,7 @@ describe('SupportPolicyEditor', () => {
         channels: [{ type: 'web', url: 'https://example.com' }]
       }]
     };
-    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy } })
+    const wrapper = mount(SupportPolicyEditor, { props: { supportPolicy: policy }, global: globalOptions })
 
     const select = wrapper.find('select');
     

--- a/tests/integration/description-tab.spec.ts
+++ b/tests/integration/description-tab.spec.ts
@@ -34,4 +34,28 @@ test.describe('Description Tab', () => {
     await expect(description).toContainText('Cost: 10 UNIT');
     await expect(description).toContainText('(Equivalent to 50.00 EUR)');
   });
+
+  test('should reflect holiday calendar names in description', async ({ page }) => {
+    await page.click('text=GUI');
+    
+    // Add Plan
+    await page.fill('input[placeholder="New plan name"]', 'Gold');
+    await page.click('button:has-text("Add Plan")');
+
+    // Add Holiday Source
+    await page.click('button:has-text("Add Holiday Source")');
+    const holidaySource = page.locator('.holiday-source-item').first();
+    await holidaySource.locator('select').selectOption('ical');
+    
+    const input = holidaySource.locator('input[placeholder="https://example.com/holidays.ics"]');
+    await input.fill('https://calendar.google.com/calendar/ical/de.by%23holiday%40group.v.calendar.google.com/public/basic.ics');
+    await input.dispatchEvent('input');
+
+    // Go to Description tab
+    await page.click('text=Description');
+    
+    const description = page.locator('.policy-description');
+    await expect(description).toContainText('Germany: Bavaria Holidays');
+    await expect(description).toContainText('(from feed: https://calendar.google.com/calendar/ical/de.by%23holiday%40group.v.calendar.google.com/public/basic.ics)');
+  });
 });

--- a/tests/integration/holiday-calendar.spec.ts
+++ b/tests/integration/holiday-calendar.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Holiday Calendar Search', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('should allow searching and selecting a holiday calendar', async ({ page }) => {
+    // Add a plan first
+    await page.fill('input[placeholder="New plan name"]', 'Gold');
+    await page.click('button:has-text("Add Plan")');
+
+    // Navigate to Support Policy
+    await page.click('button:has-text("Add Holiday Source")');
+    
+    // Select iCal type
+    const holidaySource = page.locator('.holiday-source-item').first();
+    await holidaySource.locator('select').selectOption('ical');
+    
+    // Check if datalist exists and has options
+    const input = holidaySource.locator('input[placeholder="https://example.com/holidays.ics"]');
+    await expect(input).toBeVisible();
+    
+    const listId = await input.getAttribute('list');
+    expect(listId).toBeDefined();
+    
+    // Type "Germany" in the input
+    await input.fill('Germany');
+    
+    // Since it's a datalist, we can't easily "click" an option in Playwright without some tricks,
+    // but we can verify the datalist content
+    const datalist = page.locator(`datalist#${listId}`);
+    const option = datalist.locator('option[value*="german.official"]');
+    await expect(option).toBeAttached();
+    
+    // Set the value directly to simulate selection
+    const url = await option.getAttribute('value');
+    await input.fill(url!);
+    await input.dispatchEvent('input');
+
+    // Switch to Source tab to see YAML
+    await page.click('a:has-text("Source")');
+
+    // Verify YAML update
+    const yamlEditor = page.locator('.ace_content');
+    await expect(yamlEditor).toContainText('https://calendar.google.com/calendar/ical/en.german.official%23holiday%40group.v.calendar.google.com/public/basic.ics');
+  });
+
+  test('should show German states in the holiday list', async ({ page }) => {
+    // Add a plan first
+    await page.fill('input[placeholder="New plan name"]', 'Silver');
+    await page.click('button:has-text("Add Plan")');
+
+    await page.click('button:has-text("Add Holiday Source")');
+    const holidaySource = page.locator('.holiday-source-item').first();
+    await holidaySource.locator('select').selectOption('ical');
+    
+    const input = holidaySource.locator('input[placeholder="https://example.com/holidays.ics"]');
+    const listId = await input.getAttribute('list');
+    const datalist = page.locator(`datalist#${listId}`);
+    
+    const bavariaOption = datalist.locator('option:has-text("Germany: Bavaria Holidays")');
+    await expect(bavariaOption).toBeAttached();
+    const bavariaUrl = await bavariaOption.getAttribute('value');
+    expect(bavariaUrl).toContain('de.by%23holiday');
+  });
+});

--- a/tests/unit/holidays.vitest.spec.ts
+++ b/tests/unit/holidays.vitest.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { getGoogleHolidayCalendarUrl, getHolidayCalendarId, getAllHolidayCalendars, getHolidayCalendarName } from '../../src/utils/holidays';
+
+describe('Holiday Utilities', () => {
+  it('should generate correct Google Calendar iCal URL', () => {
+    const id = 'en.usa.official#holiday@group.v.calendar.google.com';
+    const url = getGoogleHolidayCalendarUrl(id);
+    expect(url).toBe('https://calendar.google.com/calendar/ical/en.usa.official%23holiday%40group.v.calendar.google.com/public/basic.ics');
+  });
+
+  it('should get correct holiday ID for special cases', () => {
+    expect(getHolidayCalendarId('US')).toBe('en.usa.official#holiday@group.v.calendar.google.com');
+    expect(getHolidayCalendarId('DE')).toBe('en.german.official#holiday@group.v.calendar.google.com');
+  });
+
+  it('should get default pattern holiday ID for other countries', () => {
+    expect(getHolidayCalendarId('BG')).toBe('en.bg.official#holiday@group.v.calendar.google.com');
+  });
+
+  it('should return a sorted list of all holiday calendars', () => {
+    const all = getAllHolidayCalendars();
+    expect(all.length).toBeGreaterThan(100);
+    expect(all[0].name.localeCompare(all[1].name)).toBeLessThanOrEqual(0);
+    
+    const usHolidays = all.find(c => c.name === 'US Holidays');
+    expect(usHolidays).toBeDefined();
+    expect(usHolidays.id).toBe('en.usa.official#holiday@group.v.calendar.google.com');
+
+    const bavariaHolidays = all.find(c => c.name === 'Germany: Bavaria Holidays');
+    expect(bavariaHolidays).toBeDefined();
+  });
+
+  it('should return correct name for a holiday calendar URL', () => {
+    const url = 'https://calendar.google.com/calendar/ical/de.by%23holiday%40group.v.calendar.google.com/public/basic.ics';
+    expect(getHolidayCalendarName(url)).toBe('Germany: Bavaria Holidays');
+  });
+
+  it('should return null for an unknown holiday calendar URL', () => {
+    expect(getHolidayCalendarName('https://example.com/other.ics')).toBeNull();
+  });
+});


### PR DESCRIPTION
- Implement searchable Google Holiday Calendar iCal URLs for 110+ countries.
- Add support for regional holiday calendars (e.g., German states).
- Refactor holiday data management using Vue provide/inject pattern.
- Enhance Description tab to show friendly names for predefined holiday calendars.
- Add unit and integration tests for holiday calendar functionality.

Fix #13 