### PR TITLE
feat: implement debounced auto-save and revision history for SLAs

### DIFF
--- a/playwright-integration.config.ts
+++ b/playwright-integration.config.ts
@@ -29,11 +29,11 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
 
-    actionTimeout: 200,
+    actionTimeout: 1000,
   },
 
   expect: {
-    timeout: 500,
+    timeout: 2000,
   },
 
   /* Configure projects for major browsers */

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,13 +16,21 @@
                 <li><a class="dropdown-item btn-gen-grafana" href="#" data-bs-dismiss="dropdown" @click.prevent="setView('grafana')">Generate Grafana (Prometheus)</a></li>
               </ul>
             </div>
-             <div class="dropdown">
+            <div class="dropdown">
               <button class="btn btn-sm btn-outline-light dropdown-toggle btn-help-menu" type="button" data-bs-toggle="dropdown" :class="{ active: ['tutorial', 'help'].includes(currentView) }">
                 Help
               </button>
               <ul class="dropdown-menu">
                 <li><a class="dropdown-item btn-view-tutorial" href="#" data-bs-dismiss="dropdown" @click.prevent="setView('tutorial')">Tutorial</a></li>
                 <li><a class="dropdown-item btn-view-help" href="#" data-bs-dismiss="dropdown" @click.prevent="setView('help')">Help Page</a></li>
+              </ul>
+            </div>
+            <div class="dropdown">
+              <button class="btn btn-sm btn-outline-light dropdown-toggle btn-settings-menu" type="button" data-bs-toggle="dropdown" :class="{ active: currentView === 'history' }">
+                Settings
+              </button>
+              <ul class="dropdown-menu dropdown-menu-end">
+                <li><a class="dropdown-item btn-view-history" href="#" data-bs-dismiss="dropdown" @click.prevent="openHistory">History</a></li>
               </ul>
             </div>
           </nav>
@@ -41,6 +49,7 @@
                <li><hr class="dropdown-divider"></li>
                <li><a class="dropdown-item" href="#" data-bs-dismiss="dropdown" @click.prevent="setView('tutorial')">Tutorial</a></li>
                <li><a class="dropdown-item" href="#" data-bs-dismiss="dropdown" @click.prevent="setView('help')">Help</a></li>
+               <li><a class="dropdown-item" href="#" data-bs-dismiss="dropdown" @click.prevent="openHistory">History</a></li>
              </ul>
           </div>
 
@@ -134,7 +143,7 @@
               </div>
               <div class="card-body overflow-auto">
                 <p class="text-muted small">Load an example to get started with SLA creation.</p>
-                <select class="form-select mb-3 select-example-loader" @change="loadExample($event.target.value)">
+                <select class="form-select mb-3 select-example-loader" @change="confirmLoadExample($event.target.value)">
                   <option selected disabled>Select an example</option>
                   <option v-for="(content, name) in examples" :key="name" :value="name">
                     {{ name.replace(/-/g, ' ') }}
@@ -142,7 +151,7 @@
                 </select>
                 <div class="list-group list-group-flush mb-3 d-none">
                   <button v-for="(content, name) in examples" :key="name" 
-                    @click="loadExample(name)"
+                    @click="confirmLoadExample(name)"
                     class="list-group-item list-group-item-action">
                     {{ name.replace(/-/g, ' ') }}
                   </button>
@@ -169,6 +178,69 @@
       <GrafanaDashboardGenerator v-else-if="currentView === 'grafana'" :sla="sla" @close="setView('editor')" />
 
     </main>
+
+    <!-- Confirmation Modal -->
+    <div class="modal fade" id="confirmLoadModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Unsaved Changes</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <p>You have modified the current SLA. Loading a new example will overwrite your changes.</p>
+            <p>Are you sure you want to proceed?</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-primary" @click="proceedWithExample">Proceed</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- History Modal -->
+    <div class="modal fade" id="historyModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">SLA History</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div v-if="historyFiles.length === 0" class="text-center p-4">
+              <p class="text-muted">No history found.</p>
+            </div>
+            <div v-else class="table-responsive">
+              <table class="table table-hover">
+                <thead>
+                  <tr>
+                    <th>SLA ID</th>
+                    <th>Last Modified</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="file in historyFiles" :key="file.id">
+                    <td>{{ file.id }}</td>
+                    <td>{{ new Date(file.lastModified).toLocaleString() }}</td>
+                    <td>
+                      <div class="btn-group btn-group-sm">
+                        <button class="btn btn-outline-primary" @click="restoreFromHistory(file)">Restore</button>
+                        <button class="btn btn-outline-danger" @click="deleteFromHistory(file.id)">Delete</button>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -177,6 +249,7 @@ import { ref, onMounted, onUnmounted, watch, reactive, computed, provide, nextTi
 import { currencies } from './utils/currencies';
 import { getAllHolidayCalendars, getGoogleHolidayCalendarUrl } from './utils/holidays';
 import { validatePromQL } from './utils/formatters';
+import { saveSla, getCurrentSlaId, getSla, getAllSlas, deleteSla } from './utils/storage';
 import 'bootstrap/dist/css/bootstrap.css';
 import ace from 'ace-builds';
 import 'ace-builds/src-noconflict/mode-yaml';
@@ -231,6 +304,49 @@ export default {
     let editor = null;
     const validationErrors = ref([]);
     const markers = ref([]);
+    let processingUpdate = false;
+
+    // Storage and Dirty Tracking
+    const lastLoadedContent = ref(''); // Stores the CANONICAL YAML string
+    
+    const getNormalizedObject = (yaml) => {
+      try {
+        const doc = jsYaml.load(yaml);
+        if (!doc || typeof doc !== 'object') return yaml ? yaml.trim() : '';
+        const sortObject = (obj) => {
+          if (obj === null || typeof obj !== 'object') return obj;
+          if (Array.isArray(obj)) return obj.map(sortObject);
+          return Object.keys(obj).sort().reduce((acc, key) => {
+            acc[key] = sortObject(obj[key]);
+            return acc;
+          }, {});
+        };
+        return sortObject(doc);
+      } catch (e) {
+        return yaml ? yaml.trim() : '';
+      }
+    };
+
+    const sla = reactive({
+      sla: "1.0.0", // Required by schema
+      context: { id: 'example-sla', type: 'plans' }, // Default structure for context editor
+      metrics: {},
+      plans: {},
+      customCurrencies: []
+    });
+
+    const isDirty = computed(() => {
+      if (!lastLoadedContent.value) return false;
+      // We compare current canonical YAML with last loaded canonical YAML
+      // This is efficient and handles all sorting/formatting because it's always generated from the model
+      const currentCanonical = jsYaml.dump(sla);
+      return currentCanonical !== lastLoadedContent.value;
+    });
+
+    const historyFiles = ref([]);
+    const pendingExample = ref(null);
+    let confirmModal = null;
+    let historyModal = null;
 
     const setView = (view) => {
       currentView.value = view;
@@ -240,6 +356,73 @@ export default {
         el.classList.remove('show');
         el.setAttribute('aria-expanded', 'false');
       });
+    };
+
+    const openHistory = () => {
+      historyFiles.value = getAllSlas();
+      if (historyModal) historyModal.show();
+    };
+
+    const confirmLoadExample = (exampleName) => {
+      if (isDirty.value) {
+        pendingExample.value = exampleName;
+        if (confirmModal) confirmModal.show();
+      } else {
+        loadExample(exampleName);
+      }
+    };
+
+    const proceedWithExample = () => {
+      if (pendingExample.value) {
+        loadExample(pendingExample.value);
+        pendingExample.value = null;
+      }
+    };
+
+    const loadExample = (exampleName) => {
+      const rawContent = examples[exampleName];
+      const doc = jsYaml.load(rawContent);
+      
+      processingUpdate = true;
+      try {
+        updateModelFromDoc(doc);
+        const canonical = jsYaml.dump(sla);
+        yamlContent.value = canonical;
+        lastLoadedContent.value = canonical;
+        if (editor) editor.setValue(canonical, -1);
+        if (confirmModal) confirmModal.hide();
+        
+        if (sla.context && sla.context.id) {
+          saveSla(sla.context.id, canonical, true);
+        }
+      } finally {
+        processingUpdate = false;
+      }
+      nextTick(() => { isProgrammaticChange = false; });
+    };
+
+    const restoreFromHistory = (file) => {
+      const doc = jsYaml.load(file.current);
+      
+      processingUpdate = true;
+      try {
+        updateModelFromDoc(doc);
+        const canonical = jsYaml.dump(sla);
+        yamlContent.value = canonical;
+        lastLoadedContent.value = canonical;
+        if (editor) editor.setValue(canonical, -1);
+        if (historyModal) historyModal.hide();
+        
+        saveSla(file.id, canonical, true);
+      } finally {
+        processingUpdate = false;
+      }
+      nextTick(() => { isProgrammaticChange = false; });
+    };
+
+    const deleteFromHistory = (id) => {
+      deleteSla(id);
+      historyFiles.value = getAllSlas();
     };
 
     const validationErrorsMap = computed(() => {
@@ -263,14 +446,6 @@ export default {
         }
       });
       return map;
-    });
-
-    const sla = reactive({
-      sla: "1.0.0", // Required by schema
-      context: { id: 'example-sla', type: 'plans' }, // Default structure for context editor
-      metrics: {},
-      plans: {},
-      customCurrencies: []
     });
 
     const examples = {
@@ -355,32 +530,45 @@ export default {
       }
     };
 
+    const updateModelFromDoc = (doc) => {
+      if (!doc || typeof doc !== 'object') return;
+      if (doc.context) Object.assign(sla.context, doc.context);
+      
+      if (doc.metrics) {
+        Object.keys(sla.metrics).forEach(key => delete sla.metrics[key]);
+        Object.assign(sla.metrics, doc.metrics);
+      } else {
+        Object.keys(sla.metrics).forEach(key => delete sla.metrics[key]);
+      }
+      
+      if (doc.plans) {
+         Object.keys(sla.plans).forEach(key => delete sla.plans[key]);
+         for (const [planName, planData] of Object.entries(doc.plans)) {
+           sla.plans[planName] = planData;
+         }
+      } else {
+         Object.keys(sla.plans).forEach(key => delete sla.plans[key]);
+      }
+      
+      if (doc.customCurrencies) {
+         sla.customCurrencies.splice(0, sla.customCurrencies.length, ...doc.customCurrencies);
+      } else {
+         sla.customCurrencies.splice(0, sla.customCurrencies.length);
+      }
+      
+      if (doc.sla) sla.sla = doc.sla;
+    };
+
     const validateYaml = (content) => {
       try {
         const doc = jsYaml.load(content);
-        if (doc && typeof doc === 'object') {
-          if (doc.context) Object.assign(sla.context, doc.context);
-          if (doc.metrics) {
-            Object.keys(sla.metrics).forEach(key => delete sla.metrics[key]);
-            Object.assign(sla.metrics, doc.metrics);
-          } else {
-            Object.keys(sla.metrics).forEach(key => delete sla.metrics[key]);
+        if (doc && typeof doc === 'object' && !processingUpdate) {
+          processingUpdate = true;
+          try {
+            updateModelFromDoc(doc);
+          } finally {
+            processingUpdate = false;
           }
-          if (doc.plans) {
-             Object.keys(sla.plans).forEach(key => delete sla.plans[key]);
-             // Deeply assign to ensure nested objects like pricing are reactive
-             for (const [planName, planData] of Object.entries(doc.plans)) {
-               sla.plans[planName] = planData;
-             }
-          } else {
-             Object.keys(sla.plans).forEach(key => delete sla.plans[key]);
-          }
-          if (doc.customCurrencies) {
-             sla.customCurrencies.splice(0, sla.customCurrencies.length, ...doc.customCurrencies);
-          } else {
-             sla.customCurrencies.splice(0, sla.customCurrencies.length);
-          }
-          if (doc.sla) sla.sla = doc.sla;
         }
 
         const valid = validate(doc);
@@ -620,19 +808,54 @@ export default {
       validateYaml(yamlContent.value);
     };
 
-    watch(yamlContent, (newVal) => {
-      validateYaml(newVal);
-    });
-
     onMounted(() => {
       window.addEventListener('resize', handleResize);
+      window.addEventListener('visibilitychange', handleVisibilityChange);
+      window.addEventListener('beforeunload', triggerImmediateSave);
       window.setYamlContent = setYamlContent; // Expose for testing
+      
+      const confirmEl = document.getElementById('confirmLoadModal');
+      if (confirmEl && window.bootstrap) confirmModal = new window.bootstrap.Modal(confirmEl);
+      const historyEl = document.getElementById('historyModal');
+      if (historyEl && window.bootstrap) historyModal = new window.bootstrap.Modal(historyEl);
+
+      const lastId = getCurrentSlaId();
+      processingUpdate = true;
+      try {
+        if (lastId) {
+          const lastSla = getSla(lastId);
+          if (lastSla) {
+            const doc = jsYaml.load(lastSla.current);
+            updateModelFromDoc(doc);
+            const canonical = jsYaml.dump(sla);
+            yamlContent.value = canonical;
+            lastLoadedContent.value = canonical;
+          }
+        } else {
+          const doc = jsYaml.load(example);
+          updateModelFromDoc(doc);
+          const canonical = jsYaml.dump(sla);
+          yamlContent.value = canonical;
+          lastLoadedContent.value = canonical;
+        }
+      } finally {
+        processingUpdate = false;
+      }
+
       initEditor();
     });
 
     onUnmounted(() => {
       window.removeEventListener('resize', handleResize);
+      window.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('beforeunload', triggerImmediateSave);
     });
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        triggerImmediateSave();
+      }
+    };
 
     watch(currentView, async (newView) => {
       if (newView === 'editor') {
@@ -660,36 +883,64 @@ export default {
       }
     });
 
+    let saveTimeout = null;
+    const triggerImmediateSave = () => {
+      if (saveTimeout) {
+        clearTimeout(saveTimeout);
+        saveTimeout = null;
+        if (sla.context && sla.context.id) {
+          saveSla(sla.context.id, yamlContent.value);
+        }
+      }
+    };
+
     watch(yamlContent, (newContent) => {
       validateYaml(newContent);
+      if (saveTimeout) clearTimeout(saveTimeout);
+      saveTimeout = setTimeout(() => {
+        if (sla.context && sla.context.id) {
+          saveSla(sla.context.id, newContent);
+          saveTimeout = null;
+        }
+      }, 2000); // 2 second debounce for auto-save
     });
 
     watch(sla, (newSla) => {
+      if (processingUpdate) return;
       const newYaml = jsYaml.dump(newSla);
-      if (yamlContent.value !== newYaml) {
-        isProgrammaticChange = true;
-        yamlContent.value = newYaml;
-        if (editor) {
-          editor.setValue(newYaml, -1);
+      const currentNorm = getNormalizedObject(yamlContent.value);
+      const newNorm = getNormalizedObject(newYaml);
+      
+      if (JSON.stringify(currentNorm) !== JSON.stringify(newNorm)) {
+        processingUpdate = true;
+        try {
+          isProgrammaticChange = true;
+          yamlContent.value = newYaml;
+          if (editor) {
+            editor.setValue(newYaml, -1);
+          }
+          nextTick(() => { isProgrammaticChange = false; });
+        } finally {
+          processingUpdate = false;
         }
-        isProgrammaticChange = false;
       }
     }, { deep: true });
 
-    const loadExample = (exampleName) => {
-      isProgrammaticChange = true;
-      yamlContent.value = examples[exampleName];
-      editor.setValue(yamlContent.value, -1);
-      isProgrammaticChange = false;
-    };
-
     const setYamlContent = (content) => {
-      yamlContent.value = content;
-      if (editor) {
-        isProgrammaticChange = true;
-        editor.setValue(content, -1);
-        isProgrammaticChange = false;
+      const doc = jsYaml.load(content);
+      processingUpdate = true;
+      try {
+        updateModelFromDoc(doc);
+        const canonical = jsYaml.dump(sla);
+        yamlContent.value = canonical;
+        lastLoadedContent.value = canonical;
+        if (editor) {
+          editor.setValue(canonical, -1);
+        }
+      } finally {
+        processingUpdate = false;
       }
+      nextTick(() => { isProgrammaticChange = false; });
     };
 
     const jumpToError = async (line) => {
@@ -714,11 +965,18 @@ export default {
       validationErrors,
       validationErrorsMap,
       sla,
+      isDirty,
       examples,
       loadExample,
+      confirmLoadExample,
+      proceedWithExample,
+      openHistory,
+      restoreFromHistory,
+      deleteFromHistory,
       setYamlContent,
       jumpToError,
       setView,
+      historyFiles,
     };
   },
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import './assets/main.css'
-import 'bootstrap/dist/js/bootstrap.bundle.min.js'
+import * as bootstrap from 'bootstrap'
+window.bootstrap = bootstrap
 import 'bootstrap-icons/font/bootstrap-icons.css'
 
 import { createApp } from 'vue'

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,92 @@
+
+const STORAGE_KEY = 'sla-editor-files';
+const CURRENT_ID_KEY = 'sla-editor-current-id';
+const MAX_HISTORY = 50;
+const HISTORY_THRESHOLD = 5 * 60 * 1000; // 5 minutes between history points
+
+export interface SlaVersion {
+  content: string;
+  timestamp: number;
+}
+
+export interface SlaFile {
+  id: string;
+  current: string;
+  history: SlaVersion[];
+  lastModified: number;
+}
+
+export interface SlaStorage {
+  [id: string]: SlaFile;
+}
+
+export function getStorage(): SlaStorage {
+  const data = localStorage.getItem(STORAGE_KEY);
+  if (!data) return {};
+  try {
+    return JSON.parse(data);
+  } catch (e) {
+    console.error('Failed to parse storage', e);
+    return {};
+  }
+}
+
+export function saveStorage(storage: SlaStorage) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(storage));
+}
+
+export function saveSla(id: string, content: string, forceHistory = false) {
+  const storage = getStorage();
+  const now = Date.now();
+  
+  if (!storage[id]) {
+    storage[id] = {
+      id,
+      current: content,
+      history: [{ content, timestamp: now }],
+      lastModified: now
+    };
+  } else {
+    const file = storage[id];
+    // Only update if content changed
+    if (file.current !== content) {
+      const lastEntry = file.history[0];
+      const shouldPushHistory = forceHistory || !lastEntry || (now - lastEntry.timestamp > HISTORY_THRESHOLD);
+
+      if (shouldPushHistory) {
+        file.history.unshift({ content: file.current, timestamp: file.lastModified });
+        if (file.history.length > MAX_HISTORY) {
+          file.history.pop();
+        }
+      }
+      file.current = content;
+      file.lastModified = now;
+    }
+  }
+  
+  saveStorage(storage);
+  localStorage.setItem(CURRENT_ID_KEY, id);
+}
+
+export function getCurrentSlaId(): string | null {
+  return localStorage.getItem(CURRENT_ID_KEY);
+}
+
+export function getSla(id: string): SlaFile | null {
+  const storage = getStorage();
+  return storage[id] || null;
+}
+
+export function getAllSlas(): SlaFile[] {
+  const storage = getStorage();
+  return Object.values(storage).sort((a, b) => b.lastModified - a.lastModified);
+}
+
+export function deleteSla(id: string) {
+  const storage = getStorage();
+  delete storage[id];
+  saveStorage(storage);
+  if (getCurrentSlaId() === id) {
+    localStorage.removeItem(CURRENT_ID_KEY);
+  }
+}

--- a/tests/integration/azure-bicep-generator.spec.ts
+++ b/tests/integration/azure-bicep-generator.spec.ts
@@ -2,41 +2,59 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Azure Bicep Generator', () => {
   test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    
+    // Disable animations for faster, more reliable tests
+    await page.addInitScript(() => {
+      const style = document.createElement('style');
+      style.innerHTML = `
+        *, *::before, *::after {
+          transition: none !important;
+          animation: none !important;
+        }
+      `;
+      document.head.appendChild(style);
+    });
+
     await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
   });
 
-  test('should have Generate button disabled when configuration is missing', async ({ page }) => {
-    // Navigate to Bicep Generator
-    await page.click('button:has-text("Transform")');
-    await page.click('a:has-text("Generate Bicep (Azure)")');
+  async function navigateToBicep(page) {
+    await page.click('.btn-transform');
+    const bicepLink = page.locator('.btn-gen-bicep');
+    await expect(bicepLink).toBeVisible();
+    await bicepLink.click({ force: true });
+    await expect(page.locator('.azure-bicep-generator')).toBeVisible();
+  }
 
-    // Expect Generate button to be disabled initially
+  test('should have Generate button disabled when configuration is missing', async ({ page }) => {
+    await navigateToBicep(page);
     await expect(page.locator('.azure-bicep-generator button:has-text("Generate")')).toBeDisabled();
   });
 
   test('should generate bicep when configuration is provided in the generator view', async ({ page }) => {
-    // 1. Configure a Metric and a Plan first (needed for alerts)
-    await page.locator('#metrics-editor .card-header').filter({ hasText: 'Metrics' }).click();
+    // 1. Configure a Metric and a Plan first
+    await page.locator('#metrics-editor .card-header').click();
     await page.fill('input[placeholder="New metric name"]', 'cpu_util');
     await page.click('button:has-text("Add Metric")');
     const metricCard = page.locator('.metrics-editor-component .card').filter({ hasText: 'cpu_util' });
     await metricCard.locator('input[placeholder*="compute.googleapis.com"]').fill('percentage_cpu');
 
-    await page.locator('#plans-editor .card-header').filter({ hasText: 'Plans' }).click();
+    await page.locator('#plans-editor .card-header').click();
     await page.fill('input[placeholder="New plan name"]', 'Basic');
     await page.click('button:has-text("Add Plan")');
     const planCard = page.locator('.plans-editor-component .card').filter({ hasText: 'Basic' });
     await planCard.getByRole('button', { name: 'Add Guarantee' }).click();
     const guaranteeRow = planCard.locator('.guarantees-editor-component .card.mb-2').first();
-    // Configure metric and value in measurement mode (which is default)
     await guaranteeRow.locator('select.metric-select').selectOption('cpu_util');
     await guaranteeRow.locator('.input-promql-value').fill('90');
 
     // 2. Navigate to Bicep Generator
-    await page.click('button:has-text("Transform")');
-    await page.click('a:has-text("Generate Bicep (Azure)")');
+    await navigateToBicep(page);
 
-    // 3. Fill Azure configuration in the generator view
+    // 3. Fill Azure configuration
     await page.locator('.input-azure-resource-id').fill('/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm');
     await page.locator('.input-azure-location').fill('westeurope');
 
@@ -55,18 +73,16 @@ test.describe('Azure Bicep Generator', () => {
     };
 
     const bicep = await getEditorValue();
-    // 'cpu_util < 90' is PromQL, so it generates Rule Group
     expect(bicep).toContain("resource rule_basic_direct_0 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01'");
     expect(bicep).toContain("'/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm'");
   });
 
   test('should generate bicep with valid configuration from sample', async ({ page }) => {
     // 1. Load the Azure Monitoring Sample
-    await page.selectOption('select', 'azure-monitoring-sample');
+    await page.selectOption('select.select-example-loader', 'azure-monitoring-sample');
 
     // 2. Navigate to Bicep Generator
-    await page.click('button:has-text("Transform")');
-    await page.click('a:has-text("Generate Bicep (Azure)")');
+    await navigateToBicep(page);
 
     // Fill configuration
     await page.locator('.input-azure-resource-id').fill('/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm');
@@ -87,20 +103,15 @@ test.describe('Azure Bicep Generator', () => {
     };
 
     const bicep = await getEditorValue();
-
     expect(bicep).toContain("resource ag_Support_Team 'Microsoft.Insights/actionGroups@2023-01-01'");
     expect(bicep).toContain("emailAddress: 'support@example.com'");
-    // Sample uses complex queries
     expect(bicep).toContain("resource rule_gold_direct_0 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01'");
     expect(bicep).toContain("expression: 'avg_over_time(percentage_cpu[5m]) < 80'");
     expect(bicep).toContain("actionGroupId: ag_Support_Team.id");
   });
 
   test('should load azure-monitoring-sample without validation errors', async ({ page }) => {
-    // 1. Load the Azure Monitoring Sample
-    await page.selectOption('select', 'azure-monitoring-sample');
-
-    // 2. Check validation badge
+    await page.selectOption('select.select-example-loader', 'azure-monitoring-sample');
     const badge = page.locator('header .badge');
     await expect(badge).toBeVisible();
     await expect(badge).toHaveText('Valid');

--- a/tests/integration/comprehensive-errors.spec.ts
+++ b/tests/integration/comprehensive-errors.spec.ts
@@ -4,7 +4,21 @@ test.describe('Comprehensive Validation Errors', () => {
   const planName = 'ErrorPlan';
 
   test.beforeEach(async ({ page }) => {
+    // Disable animations for faster, more reliable tests
+    await page.addInitScript(() => {
+      const style = document.createElement('style');
+      style.innerHTML = `
+        *, *::before, *::after {
+          transition: none !important;
+          animation: none !important;
+        }
+      `;
+      document.head.appendChild(style);
+    });
+
     await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
     await page.click('.btn-tab-gui');
     
     // Add a metric

--- a/tests/integration/history-storage.spec.ts
+++ b/tests/integration/history-storage.spec.ts
@@ -1,0 +1,227 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('SLA Storage and History', () => {
+  test.beforeEach(async ({ page }) => {
+    // Desktop viewport
+    await page.setViewportSize({ width: 1280, height: 720 });
+    
+    // Disable animations for faster, more reliable tests
+    await page.addInitScript(() => {
+      const style = document.createElement('style');
+      style.innerHTML = `
+        *, *::before, *::after {
+          transition: none !important;
+          animation: none !important;
+        }
+      `;
+      document.head.appendChild(style);
+    });
+
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+  });
+
+  async function getEditorValue(page) {
+    return await page.evaluate(() => {
+      const el = document.querySelector('.ace_editor');
+      if (!el) return '';
+      // @ts-ignore
+      const editor = ace.edit(el);
+      return editor.getValue();
+    });
+  }
+
+  async function openHistoryViaUI(page) {
+    await page.click('.btn-settings-menu');
+    const historyBtn = page.locator('.btn-view-history:visible');
+    await expect(historyBtn).toBeVisible();
+    await historyBtn.click({ force: true });
+    await expect(page.locator('#historyModal')).toBeVisible();
+  }
+
+  test('should auto-save changes to localStorage', async ({ page }) => {
+    await page.click('.btn-tab-source');
+    
+    const uniqueId = `save-id-${Date.now()}`;
+    await page.evaluate((id) => {
+      window.setYamlContent(`sla: 1.0.0\ncontext:\n  id: ${id}\n  type: plans\nmetrics: {}\nplans: {}`);
+    }, uniqueId);
+    
+    // Wait for auto-save (debounce is 2s)
+    await expect(async () => {
+        const stored = await page.evaluate(() => localStorage.getItem('sla-editor-files'));
+        expect(stored).toContain(uniqueId);
+    }).toPass({ timeout: 5000 });
+
+    // Refresh page
+    await page.reload();
+
+    // Check if it's restored
+    await page.click('.btn-tab-source');
+    await expect(async () => {
+        const content = await getEditorValue(page);
+        expect(content).toContain(uniqueId);
+    }).toPass();
+  });
+
+  test('should save immediately on page reload (before debounce)', async ({ page }) => {
+    await page.click('.btn-tab-source');
+    
+    const uniqueId = `immediate-save-${Date.now()}`;
+    await page.evaluate((id) => {
+      window.setYamlContent(`sla: 1.0.0\ncontext:\n  id: ${id}\n  type: plans\nmetrics: {}\nplans: {}`);
+    }, uniqueId);
+    
+    // Reload immediately without waiting for debounce
+    await page.reload();
+
+    // Check if it's restored
+    await page.click('.btn-tab-source');
+    const content = await getEditorValue(page);
+    expect(content).toContain(uniqueId);
+  });
+
+  test('should show confirmation modal when overwriting modified SLA (Source Mode)', async ({ page }) => {
+    await page.selectOption('.select-example-loader', 'support-mon-fri');
+    
+    await page.click('.btn-tab-source');
+    await page.evaluate(() => {
+      const el = document.querySelector('.ace_editor');
+      // @ts-ignore
+      const editor = ace.edit(el);
+      editor.setValue(editor.getValue().replace('id: support-mon-fri', 'id: modified-source-id'), -1);
+      editor._emit('change');
+    });
+
+    // Try to load another example
+    await page.selectOption('.select-example-loader', 'metrics-100-concurrent-connections');
+
+    // Modal should appear
+    const modal = page.locator('#confirmLoadModal');
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText('You have modified the current SLA');
+
+    // Click Proceed
+    await page.click('#confirmLoadModal .btn-primary');
+    await expect(modal).toBeHidden();
+
+    // Check if new example is loaded
+    const content = await getEditorValue(page);
+    expect(content).toContain('metrics');
+    expect(content).not.toContain('modified-source-id');
+  });
+
+  test('should show confirmation modal when overwriting modified SLA (GUI Mode)', async ({ page }) => {
+    await page.selectOption('.select-example-loader', 'support-mon-fri');
+    
+    // Modify it in GUI
+    await page.click('.btn-tab-gui');
+    await page.fill('input#context-id', 'gui-modified-id');
+    
+    // Wait for isDirty to become true (via normalized comparison)
+    await expect(async () => {
+        const isDirty = await page.evaluate(() => {
+            // @ts-ignore
+            return window.app.isDirty;
+        });
+        expect(isDirty).toBe(true);
+    }).toPass();
+
+    // Try to load another example
+    await page.selectOption('.select-example-loader', 'metrics-100-concurrent-connections');
+
+    // Modal should appear
+    const modal = page.locator('#confirmLoadModal');
+    await expect(modal).toBeVisible();
+
+    // Click Proceed
+    await page.click('#confirmLoadModal .btn-primary');
+    await expect(modal).toBeHidden();
+
+    // Check if new example is loaded
+    await page.click('.btn-tab-source');
+    const content = await getEditorValue(page);
+    expect(content).toContain('metrics');
+    expect(content).not.toContain('gui-modified-id');
+  });
+
+  test('should detect dirty state when modifying via GUI and reload', async ({ page }) => {
+    await page.click('.btn-tab-gui');
+    const uniqueId = `gui-save-${Date.now()}`;
+    await page.fill('input#context-id', uniqueId);
+    
+    // Wait for sync to yamlContent
+    await expect(async () => {
+        const content = await getEditorValue(page);
+        expect(content).toContain(uniqueId);
+    }).toPass();
+    
+    await page.reload();
+    
+    await page.click('.btn-tab-source');
+    const content = await getEditorValue(page);
+    expect(content).toContain(uniqueId);
+  });
+
+  test('should NOT show confirmation modal if NOT modified between samples', async ({ page }) => {
+    await page.selectOption('.select-example-loader', 'support-mon-fri');
+    
+    // Ensure NOT dirty
+    await expect(async () => {
+        const isDirty = await page.evaluate(() => {
+            // @ts-ignore
+            return window.app.isDirty;
+        });
+        expect(isDirty).toBe(false);
+    }).toPass();
+    
+    await page.selectOption('.select-example-loader', 'metrics-100-concurrent-connections');
+
+    const modal = page.locator('#confirmLoadModal');
+    await expect(modal).toBeHidden();
+
+    const content = await getEditorValue(page);
+    expect(content).toContain('metrics');
+  });
+
+  test('should show history and allow restoration', async ({ page }) => {
+    test.setTimeout(60000);
+    
+    await page.click('.btn-tab-source');
+    const historyId = `history-test-${Date.now()}`;
+    await page.evaluate((id) => {
+      window.setYamlContent(`sla: 1.0.0\ncontext:\n  id: ${id}\n  type: plans\nmetrics: {}\nplans: {}`);
+    }, historyId);
+    
+    // Wait for auto-save
+    await expect(async () => {
+        const stored = await page.evaluate(() => localStorage.getItem('sla-editor-files'));
+        expect(stored).toContain(historyId);
+    }).toPass();
+
+    await openHistoryViaUI(page);
+    await expect(page.locator('#historyModal td').first()).toContainText(historyId);
+
+    // Close modal
+    await page.click('#historyModal .btn-secondary');
+    await expect(page.locator('#historyModal')).toBeHidden();
+    
+    // Load a different example to change current state
+    await page.selectOption('.select-example-loader', 'support-mon-fri');
+    
+    // Open History again
+    await openHistoryViaUI(page);
+    
+    // Restore historyId specifically
+    const row = page.locator('#historyModal tr', { hasText: historyId });
+    await row.locator('.btn-outline-primary').click();
+    await expect(page.locator('#historyModal')).toBeHidden();
+    
+    // Check if restored
+    await expect(async () => {
+        const content = await getEditorValue(page);
+        expect(content).toContain(historyId);
+    }).toPass();
+  });
+});


### PR DESCRIPTION
- Implemented localStorage persistence with 2s debounce during editing.
- Added immediate save on page leave/reload to prevent data loss.
- Implemented revision history (up to 50 versions) with 5-minute throttling.
- Added normalized canonical YAML comparison for robust 'dirty' state detection.
- Added confirmation modal when overwriting modified work with samples.
- Introduced Settings > History menu for revision management.
- Standardized modal initialization via global bootstrap object.
- Stabilized integration tests by disabling animations and improving timeout handling.
- Added comprehensive history-storage.spec.ts test suite.

Implement #30 